### PR TITLE
Unit Tests for /datum/atmosphere

### DIFF
--- a/code/datums/atmosphere/_atmosphere.dm
+++ b/code/datums/atmosphere/_atmosphere.dm
@@ -51,12 +51,11 @@
 		ASSERT_GAS(gastype, gasmix)
 		gaslist[gastype][MOLES] += amount
 
-	/* CURRENTLY DISABLED AS I DONT KNOW WHY THIS RUNTIMES AND BREAKS A LOT OF THINGS (cannot read list)
 	// That last one put us over the limit, remove some of it
 	while(gasmix.return_pressure() > target_pressure)
 		gaslist[gastype][MOLES] -= gaslist[gastype][MOLES] * 0.1
+
 	gaslist[gastype][MOLES] = FLOOR(gaslist[gastype][MOLES], 0.1)
-	*/
 	gasmix.garbage_collect()
 
 	// Now finally lets make that string

--- a/code/modules/unit_tests/_unit_tests.dm
+++ b/code/modules/unit_tests/_unit_tests.dm
@@ -69,6 +69,7 @@
 #include "achievements.dm"
 #include "anchored_mobs.dm"
 #include "anonymous_themes.dm"
+#include "atmosphere.dm"
 #include "autowiki.dm"
 #include "barsigns.dm"
 #include "bespoke_id.dm"

--- a/code/modules/unit_tests/atmosphere.dm
+++ b/code/modules/unit_tests/atmosphere.dm
@@ -1,0 +1,25 @@
+#define TEST_ATMOS_MESSAGE(test_atmos, message) "[test_atmos.type] [message]"
+
+// Tests all `/datum/atmosphere` for general sanity.
+// This is mainly a test for `/datum/atmosphere/proc/generate_gas_string()`.
+/datum/unit_test/atmosphere_sanity
+
+/datum/unit_test/atmosphere_sanity/Run()
+	for (var/datum/atmosphere/test_atmos_type as anything in subtypesof(/datum/atmosphere))
+		test_atmosphere(test_atmos_type)
+
+/datum/unit_test/atmosphere_sanity/proc/test_atmosphere(datum/atmosphere/test_atmos_type)
+	var/datum/atmosphere/test_atmos = new test_atmos_type
+	test_gases("`base_gases`", test_atmos, test_atmos.base_gases)
+	test_gases("`normal_gases`", test_atmos, test_atmos.normal_gases)
+	test_gases("`restricted_gases`", test_atmos, test_atmos.restricted_gases)
+	TEST_ASSERT(istype(SSair.parse_gas_string(test_atmos.gas_string), /datum/gas_mixture), TEST_ATMOS_MESSAGE(test_atmos, "generated a `gas_string` which can not be parsed by `parse_gas_string`."))
+
+/datum/unit_test/atmosphere_sanity/proc/test_gases(context, datum/atmosphere/test_atmos, list/test_gases)
+	for(var/datum/gas_type in test_gases)
+		TEST_ASSERT(istype(gas_type, /datum/gas), TEST_ATMOS_MESSAGE(test_atmos, "should only have `/datum/gas` in [context]."))
+		TEST_ASSERT(GLOB.gaslist_cache[gas_type], TEST_ATMOS_MESSAGE(test_atmos, "has `[gas_type]` in [context] but it does not exist in `GLOB.gaslist_cache`."))
+
+	return
+
+#undef TEST_ATMOS_MESSAGE


### PR DESCRIPTION
## About The Pull Request

This PR adds a unit test for all subtypes of `/datum/atmosphere` to @RimiNosha 's PR #56

## How This Contributes To The Artea Roleplay Experience

This test will help us root out some of the bugs we've been seeing with `/datum/atmosphere`

## Changelog

:cl:
add: Added unit tests for /datum/atmosphere.
/:cl:
